### PR TITLE
Font updates

### DIFF
--- a/examples/ant/package.json
+++ b/examples/ant/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@enterprise-oss/osso": "latest",
+    "@enterprise-oss/osso": "file:.yalc/@enterprise-oss/osso",
     "antd": "^4.4.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "rollup-plugin-svg": "^2.0.0",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.27.1",
-    "rollup-plugin-url": "^3.0.1",
     "ts-jest": "^26.1.4",
     "tslib": "^2.0.0",
     "typescript": "^3.9.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@enterprise-oss/osso",
   "license": "SEE LICENSE IN LICENSE",
-  "version": "0.0.9-alpha.6",
+  "version": "0.0.9-alpha.7",
   "description": "React components for Osso",
   "main": "umd/osso.js",
   "module": "dist/index.esm.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,6 @@ import alias from '@rollup/plugin-alias';
 import svg from 'rollup-plugin-svg';
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
-import url from 'rollup-plugin-url';
 
 import pkg from './package.json';
 
@@ -17,10 +16,6 @@ const external = [
 const plugins = [
   alias({
     entries: [{ find: '~', replacement: 'src' }],
-  }),
-  url({
-    include: ['src/resources/SFMono-Regular.ttf'],
-    limit: Infinity,
   }),
   svg({ base64: true }),
 ];

--- a/src/hooks/useOssoDocs/index.ts
+++ b/src/hooks/useOssoDocs/index.ts
@@ -1,6 +1,6 @@
 import { HttpLink } from '@apollo/client';
 import download from 'downloadjs';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 
 import OssoContext from '~client';
 import generateDocumentation, { PDF_VERSION } from '~utils/documentationWriter';
@@ -12,13 +12,19 @@ const useOssoDocs = (
   id: string,
 ): {
   downloadDocs: () => void;
+  loading: boolean;
 } => {
   const { data } = useIdentityProvider(id);
   const { data: appData } = useAppConfig();
   const { baseUrl, client } = useContext(OssoContext);
+  const [loading, setLoading] = useState(false);
 
   const downloadDocs = async () => {
-    if (!(data && appData)) return;
+    if (!(data && appData)) {
+      console.error('data', data, 'appConfig', appData);
+      return;
+    }
+    setLoading(true);
     const {
       identityProvider: { service, domain },
     } = data;
@@ -34,9 +40,11 @@ const useOssoDocs = (
     }).then((res) => res.arrayBuffer());
     const pdf = await generateDocumentation(template, data.identityProvider, appData.appConfig);
     download(pdf, `${service} SAML setup - ${domain}.pdf`, 'application/pdf');
+    setLoading(false);
   };
   return {
     downloadDocs,
+    loading,
   };
 };
 

--- a/src/utils/documentationWriter/index.ts
+++ b/src/utils/documentationWriter/index.ts
@@ -1,13 +1,8 @@
 import fontkit from '@pdf-lib/fontkit';
-import { decode } from 'base64-arraybuffer';
 import { PDFDocument, PDFFont, PDFPage } from 'pdf-lib';
 
 import useOssoFields from '~/hooks/useOssoFields';
 import { AppConfig, IdentityProvider } from '~/types';
-
-// NB: rollup plugins not playing well with each other,
-// so no root aliasing
-import SFMono from '../../resources/SFMono-Regular.ttf';
 
 export const PDF_VERSION = 1;
 
@@ -26,7 +21,8 @@ const generateDocumentation = async (
   const pdfDoc = await PDFDocument.load(template);
 
   pdfDoc.registerFontkit(fontkit);
-  const fontBytes = decode(SFMono);
+  const url = 'https://ossoapp.com/Mono.ttf';
+  const fontBytes = await fetch(url).then((res) => res.arrayBuffer());
   const font = await pdfDoc.embedFont(fontBytes);
   const firstPage = pdfDoc.getPages()[0];
 


### PR DESCRIPTION
Embedding a font in the bundle just seems like its not a great idea. Makes the bundle very large and I've not found a clear best way to handle it with rollup.

Instead we can host a mono font on the docs site and fetch that. It's a bit odd that this works in jest but we can circle back on that?