### PR TITLE
onUnauthorized prop for OssoProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@enterprise-oss/osso",
   "license": "SEE LICENSE IN LICENSE",
-  "version": "0.1.2",
+  "version": "0.1.2-alpha",
   "description": "React components for Osso",
   "main": "umd/osso.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@enterprise-oss/osso",
   "license": "SEE LICENSE IN LICENSE",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "React components for Osso",
   "main": "umd/osso.js",
   "module": "dist/index.esm.js",

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -58,7 +58,7 @@ const buildClient = (clientOptions?: OssoClientOptions) => {
 
   const unauthorizedLink = onError(({ networkError }) => {
     if ((networkError as ServerError)?.statusCode === 401) {
-      window.location.href = '/login';
+      clientOptions?.onUnauthorized?.();
     }
   });
 

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -1,4 +1,5 @@
-import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
+import { ApolloClient, HttpLink, InMemoryCache, ServerError } from '@apollo/client';
+import { onError } from '@apollo/client/link/error';
 import { relayStylePagination } from '@apollo/client/utilities';
 import gql from 'graphql-tag';
 import React, { createContext, ReactElement, useState } from 'react';
@@ -55,9 +56,15 @@ const buildClient = (clientOptions?: OssoClientOptions) => {
     headers,
   });
 
+  const unauthorizedLink = onError(({ networkError }) => {
+    if ((networkError as ServerError)?.statusCode === 401) {
+      window.location.href = '/login';
+    }
+  });
+
   const client = new ApolloClient({
     cache,
-    link,
+    link: unauthorizedLink.concat(link),
     defaultOptions: {
       query: {
         fetchPolicy: 'cache-first',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -157,6 +157,7 @@ export type OssoClientOptions = {
   baseUrl?: string;
   cors?: string;
   jwt?: string;
+  onUnauthorized?: () => void;
 };
 
 export type OssoContextValue = {


### PR DESCRIPTION
With the admin ui now using JWTs, we don't use server sessions to prevent access to the admin routes.

As such, when a user is unauthenticated, we'll get 401s from the graphql endpoint, and should ask the user to reauthenticate.

This adds a concatenated apollo link that catches 401s and will call the function supplied to the provider in the `onUnauthorized` prop 